### PR TITLE
Add second reference object to allow dynamic linking between felony and misdemeanor pages

### DIFF
--- a/schemas/calculator-page.ts
+++ b/schemas/calculator-page.ts
@@ -106,8 +106,15 @@ const getBaseCalculatorPageFields = (pageType: pageTypes) => {
             {
               type: 'reference',
               name: 'linkTo',
-              title: 'Link To',
+              title: `Link to ` + (pageType === pageTypes.FELONY ? `felony page` : `misdemeanor page`),
               to: [{type: pageType}],
+              hidden: ({ parent }: ParentVisibilityState) => parent.isExternalLink,
+            },
+            {
+              type: 'reference',
+              name: 'linkToOtherPageType',
+              title: `Link to ` + (pageType === pageTypes.FELONY ? `misdemeanor page` : `felony page`),
+              to: [{type: pageType === pageTypes.FELONY ? pageTypes.MISDEMEANOR : pageTypes.FELONY}],
               hidden: ({ parent }: ParentVisibilityState) => parent.isExternalLink,
             },
           ],


### PR DESCRIPTION
Previously the pages could only link to pages of their same page type. This will allow the eventual connection of the felony branch to the head, which the head lives in the misdemeanor type.