### PR TITLE
Update dependabot to use group for single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+
+    # this will raise a single pull request for all updates to a group. this separates dev and prod dependencies into two pull requests
+    groups:
+      default:
+        patterns: -"*"


### PR DESCRIPTION
Add a similar config for dependabot so that it uses one group, and opens a single PR on behalf of all dependency updates, once a week.

[11848](https://airtable.com/appfJZShN8K4tcWHU/pagXdnDYi0tVl4u8R?HjEAY=recCNQaD7XCnzWuk2)