### PR TITLE
fix: syntax for patterns in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,5 @@ updates:
     # this will raise a single pull request for all updates to a group. this separates dev and prod dependencies into two pull requests
     groups:
       default:
-        patterns: "*"
+        patterns:
+          - '*'


### PR DESCRIPTION
I am using the exact syntax shown in this figure from the docs:

![image](https://github.com/clearviction-devs/clearviction-sanity/assets/76261375/066ea187-2ef1-4a10-9f3a-3004b537caf2)
