### PR TITLE
move from weekly to monthly for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
 
     # this will raise a single pull request for all updates to a group. this separates dev and prod dependencies into two pull requests
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: 'monthly'
 
-    # this will raise a single pull request for all updates to a group. this separates dev and prod dependencies into two pull requests
+    # this will raise a single pull request for all updates to a group
     groups:
       default:
         patterns:


### PR DESCRIPTION
It is a bit cumbersome to have to review pull requests for this repository on a weekly basis when it is not used all that frequently, a move to monthly makes this more manageable.