### PR TITLE
remove undetermined link and object

### DIFF
--- a/schemas/calculator-config.js
+++ b/schemas/calculator-config.js
@@ -59,14 +59,9 @@ export default {
           title: 'Link Text',
         },
         {
-          name: 'isUndeterminedUrl',
+          name: 'feedbackUrl',
           type: 'url',
-          title: 'Eligibility Undetermined URL',
-        },
-        {
-          name: 'allOtherFeedbackUrl',
-          type: 'url',
-          title: 'All other feedback URL',
+          title: 'Feedback Form URL',
         },
       ],
     },

--- a/schemas/calculator-page.ts
+++ b/schemas/calculator-page.ts
@@ -53,14 +53,6 @@ const getBaseCalculatorPageFields = (pageType: pageTypes) => {
       description: "Is the user's conviction eligible for vacation?",
     },
     {
-      type: 'boolean',
-      name: 'isUndetermined',
-      title: 'Is Undetermined',
-      hidden: ({ parent }: ParentVisibilityState) => !parent.isFinalPage,
-      initialValue: false,
-      description: "Is the user's conviction eligibility unable to be determined at this time?",
-    },
-    {
       type: 'array',
       name: 'content',
       title: 'Content',


### PR DESCRIPTION
When the calculator was live with only the misdemeanor branch, we had a "undetermined eligibility" boolean flag in sanity, as well as a feedback form url for folks who landed on this page, when clicking that their conviction was NOT a misdemeanor. Now that the felony calculator is live we no longer need this. 

This PR corresponds with [cv-devs/cv-wa PR #237](https://github.com/clearviction-devs/clearviction-wa/pull/237).