### PR TITLE
update from deprecated desk tool to structure tool

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,5 +1,5 @@
 import {defineConfig} from 'sanity'
-import {deskTool} from 'sanity/desk'
+import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
 import {schemaTypes} from './schemas'
 import {MdSettings} from 'react-icons/md'
@@ -15,7 +15,7 @@ export default defineConfig({
   dataset: 'production',
 
   plugins: [
-    deskTool({
+    structureTool({
       structure: (S) =>
         S.list()
           .title('Content')


### PR DESCRIPTION
Fixes issue #44, the Sanity `DeskTool` has been deprecated in favor of the new `StructureTool`. Everything works identically, just swapped in a new name. [Doc here](https://www.sanity.io/help/desk-is-now-structure).

Once merged and deployed, make everyone aware of the new URL to access Sanity: 

https://clearviction.sanity.studio/desk --> https://clearviction.sanity.studio/structure